### PR TITLE
Assign flight to airline's flight dict (FlightAirlineAssignment()) + Other minor changes

### DIFF
--- a/PRG2-T13-02/Airline.cs
+++ b/PRG2-T13-02/Airline.cs
@@ -13,11 +13,11 @@ namespace PRG2_T13_02
         public Dictionary<string, Flight> Flights { get; set; }
 
         public Airline() { }
-        public Airline(string name, string code, Dictionary<string, Flight> flights)
+        public Airline(string name, string code)
         {
             Name = name;
             Code = code;
-            Flights = flights;
+            Flights = new Dictionary<string, Flight>();
         }
 
         public bool AddFlight(Flight fl)


### PR DESCRIPTION
- Created FlightAirlineAssignment(), which will assign a Flight object to the corresponding Airline's Flight Dictionary.
- Removed the need for a flight dictionary in the Airline class, as each newly created Airline would have no flights initially.
- Implemented the need for airline dictionary in LoadFlights() and CreateFlight() so when each Flight object is created, we may use FlightAirlineAssignment() to immediately tie the Flight object to the correct Airline's flight dictionary.
- In AssignBoardingGateToFlight(), amended such that the status of the flight is "On Time' when user picks "N" in deciding to update status (forgot to implement).
- Added a new column in DisplayScheduledFlights(), Special Code, which displays the special request code of the flight, as requested in documentation.