### PR TITLE
Minor rectifications

### DIFF
--- a/PRG2-T13-02/Terminal.cs
+++ b/PRG2-T13-02/Terminal.cs
@@ -70,10 +70,12 @@ namespace PRG2_T13_02
             {
                 output += $"\n{fl.ToString()}";
             }
+            output += "\nList of boarding gates:";
             foreach (BoardingGate bg in BoardingGates.Values)
             {
                 output += $"\n{bg.ToString()}";
             }
+            output += "\nList of gate fees:";
             foreach (KeyValuePair<string, double> kvp in GateFees)
             {
                 output += $"\n{kvp.Key}: ${kvp.Value}";


### PR DESCRIPTION
- Rectified issue with ToString() method in Terminal class

Objective of this PR is not for any changes, rather to test my (Caden) .csproj file and .sln file, as piror to submission of stage 1, changing the naming convention of .sln and project file resulted in .sln file not working.